### PR TITLE
modified save function of model

### DIFF
--- a/django_project/users/models.py
+++ b/django_project/users/models.py
@@ -9,8 +9,8 @@ class Profile(models.Model):
     def __str__(self):
         return f'{self.user.username} Profile'
     
-    def save(self):  # overriding the save method of the parent class
-        super().save()
+    def save(self, *args, **kwargs):  # overriding the save method of the parent class
+        super(Profile, self).save(*args, **kwargs)
 
         img = Image.open(self.image.path)  # opens the image of the current instance
 


### PR DESCRIPTION
resolve #18 

Every function has a "signature", a pattern of arguments. If you override save with a new definition that doesn't take any arguments (except the implicit self), you get the reported error when it is passed an argument it is expected to handle, e.g. force_insert. The *args, **kwargs syntax says, "collect all positional args in the args list and all keyword args in the kwargs dict". Then they can be passed along via the super call to do their work. – 
[Paul Bissex](https://stackoverflow.com/users/86233/paul-bissex)
 [Jan 4, 2021 at 0:08](https://stackoverflow.com/questions/52351756/django-typeerror-save-got-an-unexpected-keyword-argument-force-insert#comment115903765_52351829)